### PR TITLE
Update downloads parsing to handle whitespace

### DIFF
--- a/src/features/better-versions.ts
+++ b/src/features/better-versions.ts
@@ -150,7 +150,7 @@ function addCumulatedVersionsTable() {
     const publishedTd = row.querySelector('td:nth-child(3)')
     if (!downloadsTd || !publishedTd) return
     const downloadsText = downloadsTd.textContent || '0'
-    const downloads = parseInt(downloadsText.replace(/,|\./g, ''), 10) || 0
+    const downloads = parseInt(downloadsText.replace(/,|\.|\s/g, ''), 10) || 0
     const publishedText = publishedTd.textContent || ''
 
     if (!majorToInfo[major]) {


### PR DESCRIPTION
Some locales format DL numbers with spaces (e.g. `123 456`). This fixes the bug where the latter would have been parsed as `123` and not `123456`.